### PR TITLE
Use local gpg keys

### DIFF
--- a/SOURCES/unitedrpms.repo
+++ b/SOURCES/unitedrpms.repo
@@ -4,7 +4,7 @@ mirrorlist=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/mas
 enabled=1
 metadata_expire=1d
 skip_if_unavailable=1
-gpgkey=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/master/URPMS-GPG-PUBLICKEY-Fedora-24
+gpgkey=file:///etc/pki/rpm-gpg/URPMS-GPG-PUBLICKEY-Fedora-24
 gpgcheck=1
 repo_gpgcheck=1
 
@@ -14,7 +14,7 @@ mirrorlist=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/mas
 enabled=0
 metadata_expire=1d
 skip_if_unavailable=1
-gpgkey=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/master/URPMS-GPG-PUBLICKEY-Fedora-24
+gpgkey=file:///etc/pki/rpm-gpg/URPMS-GPG-PUBLICKEY-Fedora-24
 gpgcheck=1
 repo_gpgcheck=1
 
@@ -24,6 +24,6 @@ mirrorlist=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/mas
 enabled=0
 metadata_expire=1d
 skip_if_unavailable=1
-gpgkey=https://raw.githubusercontent.com/UnitedRPMs/unitedrpms.github.io/master/URPMS-GPG-PUBLICKEY-Fedora-24
+gpgkey=file:///etc/pki/rpm-gpg/URPMS-GPG-PUBLICKEY-Fedora-24
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
Once the RPM file is installed, you can use the local public keys. This is preferred since it removes one step of downloading a key.

If you merge this pull request you also might want to update https://github.com/UnitedRPMs/unitedrpms.github.io/blob/master/README.md to reflect this change
